### PR TITLE
Fix systick IRQ enable on ARMv6m/ARMv7m targets (Avoid NVIC function,…

### DIFF
--- a/kernel/src/arch/cm0/generic/gcc/kerneltimer.cpp
+++ b/kernel/src/arch/cm0/generic/gcc/kerneltimer.cpp
@@ -85,7 +85,7 @@ void KernelTimer::Config(void)
 void KernelTimer::Start(void)
 {
     M3_SysTick_Config(PORT_TIMER_FREQ); // 1KHz fixed clock...
-    M3_NVIC_EnableIRQ(M3_SYSTICK_IRQn);
+    SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
 }
 
 //---------------------------------------------------------------------------

--- a/kernel/src/arch/cm0/stm32f051/gcc/kerneltimer.cpp
+++ b/kernel/src/arch/cm0/stm32f051/gcc/kerneltimer.cpp
@@ -91,7 +91,7 @@ void KernelTimer::Config(void)
 void KernelTimer::Start(void)
 {
     M3_SysTick_Config(PORT_TIMER_FREQ); // 1KHz fixed clock...
-    M3_NVIC_EnableIRQ(M3_SYSTICK_IRQn);
+    SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
 }
 
 //---------------------------------------------------------------------------

--- a/kernel/src/arch/cm3/generic/gcc/kerneltimer.cpp
+++ b/kernel/src/arch/cm3/generic/gcc/kerneltimer.cpp
@@ -90,7 +90,7 @@ void KernelTimer::Start(void)
 
     M3_SysTick_Config(PORT_TIMER_FREQ); // 1KHz fixed clock...
     M3_NVIC_SetPriority(M3_SYSTICK_IRQn, u8Priority);
-    M3_NVIC_EnableIRQ(M3_SYSTICK_IRQn);
+    SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
 }
 
 //---------------------------------------------------------------------------

--- a/kernel/src/arch/cm3/qemu_lm3s6965evb/gcc/kerneltimer.cpp
+++ b/kernel/src/arch/cm3/qemu_lm3s6965evb/gcc/kerneltimer.cpp
@@ -98,7 +98,7 @@ void KernelTimer::Start(void)
 
     M3_SysTick_Config(PORT_TIMER_FREQ); // 1KHz fixed clock...
     M3_NVIC_SetPriority(M3_SYSTICK_IRQn, u8Priority);
-    M3_NVIC_EnableIRQ(M3_SYSTICK_IRQn);
+    SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
 }
 
 //---------------------------------------------------------------------------

--- a/kernel/src/arch/cm4f/generic/gcc/kerneltimer.cpp
+++ b/kernel/src/arch/cm4f/generic/gcc/kerneltimer.cpp
@@ -93,7 +93,7 @@ void KernelTimer::Start(void)
 
     M3_SysTick_Config(PORT_TIMER_FREQ); // 1KHz fixed clock...
     M3_NVIC_SetPriority(M3_SYSTICK_IRQn, u8Priority);
-    M3_NVIC_EnableIRQ(M3_SYSTICK_IRQn);
+    SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
 }
 
 //---------------------------------------------------------------------------

--- a/kernel/src/arch/cm4f/stm32f429/gcc/kerneltimer.cpp
+++ b/kernel/src/arch/cm4f/stm32f429/gcc/kerneltimer.cpp
@@ -104,7 +104,7 @@ void KernelTimer::Start(void)
 
     SysTick_Config(PORT_TIMER_FREQ); // 1KHz fixed clock...
     NVIC_SetPriority(SysTick_IRQn, u8Priority);
-    NVIC_EnableIRQ(SysTick_IRQn);
+    SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
… use SysTick->CTRL register access