### PR TITLE
Do not generate docs by default

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,28 +1,30 @@
-option(BUILD_DOC "Build documentation" ON)
+option(BUILD_DOC "Build documentation" OFF)
 
-add_custom_target(size_profile ALL
-    COMMAND bash ./build/tools/size_profile.sh ${mark3_arch} ${mark3_variant} ${mark3_toolchain} -d > ./kernel/src/public/sizeprofile.h
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../
-    COMMENT "Size Profiling"
-    VERBATIM )
-add_dependencies(size_profile mark3)
-
-find_package(Doxygen)
-if (DOXYGEN_FOUND)
-    set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
-    set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
-
-    configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
-
-    # note the option ALL which allows to build the docs together with the application
-    add_custom_target( doc_doxygen ALL
-        COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMENT "Generating Docs"
+if (BUILD_DOC)
+    add_custom_target(size_profile ALL
+        COMMAND bash ./build/tools/size_profile.sh ${mark3_arch} ${mark3_variant} ${mark3_toolchain} -d > ./kernel/src/public/sizeprofile.h
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../
+        COMMENT "Size Profiling"
         VERBATIM )
+    add_dependencies(size_profile mark3)
 
-    add_dependencies( doc_doxygen size_profile )
+    find_package(Doxygen)
+    if (DOXYGEN_FOUND)
+        set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
+        set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
-else (DOXYGEN_FOUND)
-  message("Skipping Doxygen documentation -- Doxygen not found")
-endif (DOXYGEN_FOUND)
+        configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+
+        # note the option ALL which allows to build the docs together with the application
+        add_custom_target( doc_doxygen ALL
+            COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Generating Docs"
+            VERBATIM )
+
+        add_dependencies( doc_doxygen size_profile )
+
+    else (DOXYGEN_FOUND)
+      message("Skipping Doxygen documentation -- Doxygen not found")
+    endif (DOXYGEN_FOUND)
+endif (BUILD_DOC)


### PR DESCRIPTION
Generating docs on every commit makes the build process
longer than necessary when docs generally don't need to
be updated with any frequency.